### PR TITLE
Mark as bot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ const bot = new LemmyBot({
     },
     federation: "all",
     dbFile: "db.sqlite3",
+    markAsBot: true,
     handlers: {
         comment: {
             handle: ({


### PR DESCRIPTION
Marking this as bot allows it to respect users' decisions to not view content from bots and also makes it more clear at first glance that this is not an actual user, as many clients differentiate bot comments from people's comments.