### PR TITLE
Add newline before link listing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const findYoutubeLinks = (text: string): string[] => {
 };
 
 const generateLinkMessage = (links: string[]): string => {
-    return `Here is an alternative Piped link(s): ${links.join(
+    return `Here is an alternative Piped link(s): \n\n${links.join(
         "\n\n",
     )}\n\nPiped is a privacy-respecting open-source alternative frontend to YouTube.\n\nI'm open-source, check me out at [GitHub](https://github.com/TeamPiped/lemmy-piped-link-bot).`;
 };


### PR DESCRIPTION
Previous formatting was inconsistent when multiple links were found.

Example:
![image](https://github.com/TeamPiped/lemmy-piped-link-bot/assets/18326238/0c6ce071-7b3a-455b-a3c0-55134896d1c3)
